### PR TITLE
Fix nestjs-zod peer dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 	},
 	"peerDependencies": {
 		"decimal.js": "^10.0.0",
-		"nestjs-zod": "^1.1.0",
+		"nestjs-zod": "^3.0.0",
 		"prisma": ">=4.0.0"
 	},
 	"peerDependenciesMeta": {


### PR DESCRIPTION
**Problem:**
Getting a warning from Yarn:
```
nestjs-zod is listed by your project with version 3.0.0, which doesn't satisfy what nestjs-zod-prisma (p2e4d0) requests (^1.1.0).
```

**Solution:**

nestjs-zod is currently at 3.0.0 and it seems the intention is to align these versions.